### PR TITLE
Feature/139/streaming merged blocks

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -10,4 +10,3 @@ app.register_blueprint(api_app)
 sockets.register_blueprint(ws)
 
 Migrate(app, db, compare_type=True)
-

--- a/api/views.py
+++ b/api/views.py
@@ -115,11 +115,11 @@ def merged_blocks_change_streaming(message, map_id):
     merge_maps = db.session.query(MergeMap).filter_by(map_id=map_id).all()
     for merge_map in merge_maps:
         merge = db.session.query(Merge).filter_by(id=merge_map.merge_id).first()
-        for block in message["blocks"]:
+        for _changed_block in message["blocks"]:
             """
                 ブロックの座標移動処理
             """
-            changed_block = copy.deepcopy(block)
+            changed_block = copy.deepcopy(_changed_block)
             rad = radians(90 * merge_map.rotate)
             tmp_x = changed_block["x"]
             tmp_y = changed_block["y"]
@@ -386,10 +386,11 @@ def get_merged_blocks(merge_id):
 
     for merge_map in merge_maps:
         blocks = db.session.query(Block).filter_by(map_id=merge_map.map_id).all()
-        for block in blocks:
+        for _block in blocks:
             """
             ブロックの座標移動処理
             """
+            block = copy.deepcopy(_block)
             rad = radians(90*merge_map.rotate)
             tmp_x = block.x
             tmp_y = block.y

--- a/api/views.py
+++ b/api/views.py
@@ -135,7 +135,7 @@ def merged_blocks_change_streaming(message, map_id):
 
     for merge_id, blocks in changed_merges.items():
         data = {
-            'map_id': str(merge_id),  # TODO: merge_idをmap_idとして扱っていて良くないのでmerge_idでwebsocket接続できるようにする
+            'merge_id': str(merge_id),
             'message': {'blocks': blocks}
         }
         redis_connection.publish('received_message', json.dumps(data))

--- a/api/views.py
+++ b/api/views.py
@@ -135,7 +135,7 @@ def merged_blocks_change_streaming(message, map_id):
 
     for merge_id, blocks in changed_merges.items():
         data = {
-            'map_id': str(merge_id),
+            'map_id': str(merge_id),  # TODO: merge_idをmap_idとして扱っていて良くないのでmerge_idでwebsocket接続できるようにする
             'message': {'blocks': blocks}
         }
         redis_connection.publish('received_message', json.dumps(data))

--- a/api/websocket.py
+++ b/api/websocket.py
@@ -5,8 +5,9 @@ import redis
 import json
 
 
-
 ws = Blueprint('websocket_app', __name__)
+
+
 class SocketClients():
     def __init__(self):
         self.clients = {}
@@ -51,6 +52,7 @@ class SocketClients():
     
 socket_clients = SocketClients()
 socket_clients.start()
+
 
 @ws.route('/receive/<uuid:map_id>/')
 def outbox(ws, map_id):

--- a/api/websocket.py
+++ b/api/websocket.py
@@ -22,24 +22,27 @@ class SocketClients():
                 continue
             yield json.loads(data.get('data'))
 
-    def register(self, client, map_id):
-        if map_id in self.clients:
-            self.clients[map_id].append(client)
+    def register(self, client, uuid):
+        if uuid in self.clients:
+            self.clients[uuid].append(client)
         else:
-            self.clients[map_id] = [client]
+            self.clients[uuid] = [client]
 
-    def send(self, client, data, map_id):
+    def send(self, client, data, uuid):
         try:
             client.send(str(data))
         except Exception:
-            self.clients[map_id].remove(client)
+            self.clients[uuid].remove(client)
 
     def run(self):
         for data in self.__iter_data():
             message = data.get('message')
             map_id = data.get('map_id')
+            merge_id = data.get('merge_id')
             if data and map_id:
                 gevent.spawn(self.castForMap, message, map_id)
+            elif data and merge_id:
+                gevent.spawn(self.castForMerge, message, merge_id)
 
     def start(self):
         gevent.spawn(self.run)
@@ -49,13 +52,18 @@ class SocketClients():
             for client in self.clients[map_id]:
                 gevent.spawn(self.send, client, message, map_id)
 
+    def castForMerge(self, message, merge_id):
+        if merge_id in self.clients:
+            for client in self.clients[merge_id]:
+                gevent.spawn(self.send, client, message, merge_id)
+
     
 socket_clients = SocketClients()
 socket_clients.start()
 
 
-@ws.route('/receive/<uuid:map_id>/')
-def outbox(ws, map_id):
-    socket_clients.register(ws, str(map_id))
+@ws.route('/receive/<uuid:uuid>/')
+def outbox(ws, uuid):
+    socket_clients.register(ws, str(uuid))
     while not ws.closed:
         gevent.sleep(0.1)


### PR DESCRIPTION
タスク[139](https://trello.com/c/5iHhwmdN/139-websocket%E9%85%8D%E4%BF%A1merge%E3%81%AE%E5%87%A6%E7%90%86%E3%82%92serve%E5%81%B4%E3%81%A7%E3%82%84%E3%82%8B)に対するPRです。


# 主な変更、追加箇所  
- /receive/<merge_id>/でmerge後の変更されたblockのデータが配信されるようにしました

# 詳細
今はmerge_idをmap_idとして扱ってwebsocket接続をしているので、merge_idでもwebsocket接続できるようにするべきなんですが、これはリファクタリングを待ってからやったほうがいいですか？
