### PR TITLE
[fix] realsenseとunity appでの座標を同じ系にする

### DIFF
--- a/api/api_views/block.py
+++ b/api/api_views/block.py
@@ -55,9 +55,9 @@ def add_block(realsense_id):
     for block in blocks:
         try:
             is_put = block['put']
-            block['x']
+            block['x'] -= 24
             block['y']
-            block['z']
+            block['z'] -= 24
         except KeyError:
             return make_response('put, x, y or z missing'), 400
 


### PR DESCRIPTION
[223](https://trello.com/c/vJip8fOd/223-原点をうまくする)